### PR TITLE
修改正则，支持负行数

### DIFF
--- a/generate_dataset.py
+++ b/generate_dataset.py
@@ -17,7 +17,7 @@ import json
 
 class StackTraceExtractor:
     def __init__(self):
-        self.JAVA_TRACE = r'\s*?at\s+([\w<>\$_]+\.)+([\w<>\$_]+)\s*\((.+?)\.java:?(\d+)?\)'
+        self.JAVA_TRACE = r'\s*?at\s+([\w<>\$_]+\.)+([\w<>\$_]+)\s*\((.+?)\.java:?(-\d+|\d+)?\)'
 
         # These two are for more 'strict' stack trace finding
         self.JAVA_EXCEPTION = r'\n(([\w<>\$_]++\.?)++[\w<>\$_]*+(Exception|Error){1}(\s|:))'


### PR DESCRIPTION
在 https://bugs.eclipse.org/bugs/show_bug.cgi?id=450439 页面中，存在数据：
at java.security.AccessController.doPrivileged(AccessController.java:-2)

原正则只能拿到正数行，虽然我也不知道为什么会有负行数。。。

∠( ᐛ 」∠)＿
